### PR TITLE
Robot Opacity Slider, Path Renaming, and Rotation Ball

### DIFF
--- a/www/autonCreator.js
+++ b/www/autonCreator.js
@@ -28,6 +28,8 @@ let prevWaypointAction = WaypointAction.NONE;
 
 let path = null;
 let paths = [];
+let robotOpacity = localStorage.hasOwnProperty("robotOpacity") ? localStorage.getItem("robotOpacity") : 1.0;
+let rotationBall = localStorage.hasOwnProperty("toggleRotationBall") ? localStorage.getItem("toggleRotationBall") : true;
 let pathSelector = document.getElementById("pathSelector");
 let sharedWaypoints = [];
 let robotWidth = 0;
@@ -51,6 +53,22 @@ let waypointAction = WaypointAction.NONE;
 
 fieldKeyboard.undoWait = false;
 fieldKeyboard.redoWait = false;
+
+/**
+ * Update robot's opacity when slider is changed
+ */
+function changeOpacity() {
+    robotOpacity = document.getElementById("opacityRange").value/100;
+    localStorage.setItem("robotOpacity", robotOpacity);
+}
+
+/**
+ * Toggle rotational ball when checkbox is changed
+ */
+function toggleRotationBall() {
+    rotationBall = document.getElementById("rotationBallCheckbox").checked;
+    localStorage.setItem("toggleRotationBall", rotationBall);
+}
 
 /**
  * Adds new path to the path selector and sets it as the selected path.
@@ -389,7 +407,7 @@ function autonCreatorDataLoop() {
         waypointAction = WaypointAction.ROTATE;
         tempMousePos = fieldMousePos;
         tempSelected = waypointSelected;
-    } else if (fieldMouseRising.l && waypointSelected &&
+    } else if (rotationBall && fieldMouseRising.l && waypointSelected &&
         path.getClosestWaypoint(adjustedMousePosPxl, 2) === selectedWaypointIndex) {
         waypointAction = WaypointAction.ROTATE;
         tempMousePos = fieldMousePos;
@@ -549,7 +567,6 @@ function autonCreatorDrawLoop() {
     if (path.getNumWaypoints() > 0) {
         // Draw waypoints
         let waypoints = path.getWaypoints();
-        let opacityRange = document.getElementById("opacityRange");
 
         for (let i in waypoints) {
             let waypoint = waypoints[i];
@@ -565,15 +582,14 @@ function autonCreatorDrawLoop() {
                 fieldContext.shadowColor = 'white';
             }
 
-            fieldContext.globalAlpha = opacityRange.value/100;
+            fieldContext.globalAlpha = robotOpacity;
             fieldContext.drawImage(robotImage, Math.floor(-robotWidthPxl * .5), Math.floor(-robotCenterPxl), Math.floor(robotWidthPxl), Math.floor(robotHeightPxl));
             
-            if (parseInt(i) === selectedWaypointIndex) {
-                fieldContext.globalAlpha = 1;
+            // draw rotation ball
+            if (rotationBall && parseInt(i) === selectedWaypointIndex) {
                 fieldContext.lineWidth = 3;
                 fieldContext.beginPath();
                 fieldContext.moveTo(0, 0);
-                //fieldContext.lineTo(waypoint.y + 5, waypoint.y);
                 fieldContext.lineTo(0, -robotWidthPxl);
                 fieldContext.stroke();
                 drawCircle(fieldContext, 0, -robotWidthPxl, 10, 'black', 'blue', 2);
@@ -652,7 +668,7 @@ function autonCreatorDrawLoop() {
                     fieldContext.save();
                     fieldContext.translate(waypointPos.x, waypointPos.y);
                     fieldContext.rotate(toRadians(-waypointRotation + 180)); // same logic as above
-                    fieldContext.globalAlpha = 0.5;
+                    fieldContext.globalAlpha = 0.5*robotOpacity;
                     fieldContext.drawImage(robotImage, Math.floor(-robotWidthPxl * .5), Math.floor(-robotCenterPxl), Math.floor(robotWidthPxl), Math.floor(robotHeightPxl));
                     fieldContext.restore();
                 }

--- a/www/autonCreator.js
+++ b/www/autonCreator.js
@@ -446,7 +446,18 @@ function autonCreatorDataLoop() {
 
     switch (waypointAction) {
         case WaypointAction.MOVE:
-            path.setWaypointXY(selectedWaypointIndex, mousePos.x, mousePos.y, prevWaypointAction !== WaypointAction.MOVE);
+
+            // snap to tile edges
+            tileWidthIn = fieldWidthIn/6
+            snapPos = mousePos;
+            if (fieldKeyboard.control) {
+                snapPos.x = Math.round(mousePos.x / tileWidthIn) * tileWidthIn;
+            }
+            if (fieldKeyboard.shift) {
+                snapPos.y = Math.round(mousePos.y / tileWidthIn) * tileWidthIn;
+            }
+
+            path.setWaypointXY(selectedWaypointIndex, snapPos.x, snapPos.y, prevWaypointAction !== WaypointAction.MOVE);
             prevWaypointAction = WaypointAction.MOVE;
             xinput.val(selectedWaypoint.x);
             yinput.val(selectedWaypoint.y);

--- a/www/autonCreator.js
+++ b/www/autonCreator.js
@@ -102,15 +102,6 @@ function renamePath() {
 }
 
 /**
- * Event listener to rename path name on right click
- */
-pathSelector.addEventListener('contextmenu', function(ev) {
-    ev.preventDefault();
-    renamePath();
-    return false;
-}, false);
-
-/**
  * Creates a new path
  */
 function newPath() {

--- a/www/autonCreator.js
+++ b/www/autonCreator.js
@@ -337,15 +337,15 @@ function autonCreatorDataLoop() {
     }
 
     lastSelectedPath = selectedPath;
-    if (fieldMouseRising.l && waypointSelected) {
-        //console.log(selectedWaypoint.angle + 180);
-        //console.log("x: " + ((Math.cos(selectedWaypoint.angle) * (fieldMousePos.x + robotWidthPxl)) + (Math.sin(selectedWaypoint.angle) * (fieldMousePos.y + robotWidthPxl))))
-        //console.log("y: " + ((Math.cos(selectedWaypoint.angle) * (fieldMousePos.y + robotWidthPxl)) - (Math.sin(selectedWaypoint.angle) * (fieldMousePos.x + robotWidthPxl))))
-        console.log("x: " + (robotWidthPxl*Math.cos(toRadians(selectedWaypoint.angle))));
-        console.log("y: " + (robotWidthPxl*Math.sin(toRadians(selectedWaypoint.angle))));
-        //console.log("x: " + (fieldMousePos.x + (robotWidthPxl*Math.cos(toRadians(selectedWaypoint.angle)))));
-        //console.log("y: " + (fieldMousePos.y + (robotWidthPxl*Math.sin(toRadians(selectedWaypoint.angle)))));
-
+    
+    // shifts mouse position from rotation ball to selected waypoint position for closest waypoint check
+    let adjustedMousePosPxl = {x: 0, y: 0};
+    if (waypointSelected) {
+        fieldMousePosIn = pixelsToInches(fieldMousePos);
+        rotateBack = rotatePoint(selectedWaypoint.x, selectedWaypoint.y, fieldMousePosIn.x,
+            fieldMousePosIn.y, selectedWaypoint.angle - 180);
+        positionBack = {x: rotateBack.x + robotWidthIn, y: rotateBack.y};
+        adjustedMousePosPxl = inchesToPixels(positionBack);
     }
     
     if (fieldMouseRising.l && waypointSelected &&
@@ -355,10 +355,8 @@ function autonCreatorDataLoop() {
         path.getClosestWaypoint(fieldMousePos, robotWidthIn / 2) === selectedWaypointIndex) {
         waypointAction = WaypointAction.ROTATE;
     } else if (fieldMouseRising.l && waypointSelected &&
-        path.getClosestWaypoint({x: (fieldMousePos.x + (robotWidthPxl*Math.cos(selectedWaypoint.angle))), y: (fieldMousePos.y + (robotWidthPxl*Math.sin(selectedWaypoint.angle)))}, 5) === selectedWaypointIndex) {
+        path.getClosestWaypoint(adjustedMousePosPxl, 2) === selectedWaypointIndex) {
         waypointAction = WaypointAction.ROTATE;
-        console.log("test");
-
     } else if (fieldMouseRising.l) {
         let selectedIndex = path.getClosestWaypoint(fieldMousePos, robotWidthIn / 2);
 
@@ -532,7 +530,7 @@ function autonCreatorDrawLoop() {
                 //fieldContext.lineTo(waypoint.y + 5, waypoint.y);
                 fieldContext.lineTo(0, -robotWidthPxl);
                 fieldContext.stroke();
-                drawCircle(fieldContext, 0, -robotWidthPxl, 5, 'black', 'blue', 2);
+                drawCircle(fieldContext, 0, -robotWidthPxl, 10, 'black', 'blue', 2);
             }
 
             fieldContext.restore();

--- a/www/index.html
+++ b/www/index.html
@@ -18,6 +18,7 @@
 <nav class="navbar-vertical navbar-expand-sm bg-light p-0">
     <form class="form-inline py-0">
         <select name="pathSelector" class="custom-select" id="pathSelector"></select>
+        <button type="button" class="btn btn-success" onclick=renamePath()>Rename Path</button>
         <button type="button" class="btn btn-success" onclick=newPath()>New Path</button>
         <button type="button" class="btn btn-success" onclick=newWaypoint()>New Waypoint</button>
         <button type="button" class="btn btn-success" onclick=newSharedWaypoint()>New Shared Waypoint</button>
@@ -28,6 +29,7 @@
         <button type="button" class="btn btn-danger" id="connect-to-robot-button" onclick=connectToRobot()>Connect to
             Robot
         </button>
+        <input type="range" min="1" max="100" value="100" class="slider" id="opacityRange">
         <button type="button" class="btn btn-info ml-auto" data-toggle="modal" data-target="#myModal">
             <i class="fas fa-cog"></i> Config
         </button>

--- a/www/index.html
+++ b/www/index.html
@@ -31,7 +31,6 @@
         </button>
         <button type="button" class="btn btn-primary" onclick=undoAction()><i class="fas fa-undo"></i></button>
         <button type="button" class="btn btn-primary" onclick=redoAction()><i class="fas fa-redo"></i></button>
-        <input type="range" min="1" max="100" value="100" class="slider" id="opacityRange">
         <button type="button" class="btn btn-info ml-auto" data-toggle="modal" data-target="#myModal">
             <i class="fas fa-cog"></i> Config
         </button>
@@ -139,6 +138,16 @@
                             Tank Drive
                         </button>
                     </div>
+                    <div class="form-group">
+                        <div>
+                            <label for="opacityRange" style="margin-top: 10px">Robot Opacity:</label>
+                        </div>
+                        <input type="range" min="1" max="100" value="100" class="slider" oninput=changeOpacity() id="opacityRange">
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" value="" id="rotationBallCheckbox" onclick=toggleRotationBall() checked>
+                        <label class="form-check-label" for="rotationBallCheckbox">Rotation Ball</label>
+                      </div>
                 </form>
             </div>
             <div class="modal-footer">

--- a/www/math.js
+++ b/www/math.js
@@ -32,3 +32,13 @@ function shortestRotationTo (target, current) {
 	counterClockwiseMove += (counterClockwiseMove < 0 ? 360 : 0);
 	return (Math.abs(clockwiseMove) < Math.abs(counterClockwiseMove) ? -clockwiseMove : counterClockwiseMove);
 }
+
+// from https://stackoverflow.com/a/17411276
+function rotatePoint(cx, cy, x, y, angle) {
+    var radians = toRadians(angle),
+        cos = Math.cos(radians),
+        sin = Math.sin(radians),
+        nx = (cos * (x - cx)) + (sin * (y - cy)) + cx,
+        ny = (cos * (y - cy)) - (sin * (x - cx)) + cy;
+    return {x: nx, y: ny};
+}

--- a/www/path.js
+++ b/www/path.js
@@ -290,7 +290,7 @@ class Path {
         };
 
         this.getClosestWaypoint = function (coordinate, radius) {
-            let mousePosInInches = pixelsToInches(fieldMousePos);
+            let mousePosInInches = pixelsToInches(coordinate);
             let closestWaypoint = -1;
             let currentLeastDistance = radius;
             for (let i in this.waypoints) {


### PR DESCRIPTION
Adds a slider to the config menu that changes the waypoint robot's opacity.
Adds a button to rename the selected path, and adds checks to make sure the user can't enter a blank name.
Adds a rotation ball to the selected waypoint's robot that allows you to rotate it without right-clicking, which is easier to use with a laptop touchpad.
Adds keybindings to snap robot to edges of tiles.

If desired, I can split each feature into their own PR.
Rebased on current master as of PR creation.